### PR TITLE
pythonのスクリプトのurlを修正

### DIFF
--- a/tweet.py
+++ b/tweet.py
@@ -4,7 +4,7 @@ import sys
 import datetime
 # from dotenv import load_dotenv テスト用
 
-BASE_URL = 'https://ebisen.com/posts'
+BASE_URL = 'https://ebisenttt.com/posts'
 
 def twitter_authorize():
   # load_dotenv('.env.local') # テスト用


### PR DESCRIPTION
github actionsで走るpythonのスクリプトのベースURLが間違っていたので修正した．