### PR TITLE
記事タイトルのインラインコードをcode要素に変換

### DIFF
--- a/src/components/post-header.tsx
+++ b/src/components/post-header.tsx
@@ -12,7 +12,7 @@ const PostHeader = ({ title, date, tag = [] }: Props) => {
   return (
     <>
       <div className="mb-12">
-        <PostTitle>{title}</PostTitle>
+        <PostTitle title={title} />
         <div className="text-center">
           {tag.map((t, i) => (
             <Badge key={`${i}_${t}`} text={t} />

--- a/src/components/post-preview.tsx
+++ b/src/components/post-preview.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link'
 
-
 import Card from '@/components/card'
 import DateFormatter from '@/components/date-formatter'
 import Badge from '@/components/badge'
+import { backQuoteToCodeElement } from '@/utils/backQuoteToCodeElement'
 
 import type PostType from '@/interfaces/post'
 
@@ -17,7 +17,10 @@ const PostPreview = ({ title, date, slug, tag = [] }: Props) => {
       className="hover:underline"
     >
       <Card>
-        <h3 className="text-xl mb-3 leading-snug">{title}</h3>
+        <h3
+          className="text-xl mb-3 leading-snug"
+          dangerouslySetInnerHTML={{ __html: backQuoteToCodeElement(title) }}
+        />
         <div className="mb-4">
           {tag.map((t, i) => (
             <Badge key={`${i}_${t}`} text={t} />

--- a/src/components/post-title.test.tsx
+++ b/src/components/post-title.test.tsx
@@ -1,0 +1,12 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+
+import PostTitle from '@/components/post-title'
+
+describe('PostTitle', () => {
+  test('タイトルが表示される', async () => {
+    const { getByText } = render(<PostTitle>タイトル</PostTitle>)
+    expect(getByText('タイトル')).toBeInTheDocument()
+  })
+})

--- a/src/components/post-title.test.tsx
+++ b/src/components/post-title.test.tsx
@@ -6,7 +6,7 @@ import PostTitle from '@/components/post-title'
 
 describe('PostTitle', () => {
   test('タイトルが表示される', async () => {
-    const { getByText } = render(<PostTitle>タイトル</PostTitle>)
+    const { getByText } = render(<PostTitle title="タイトル" />)
     expect(getByText('タイトル')).toBeInTheDocument()
   })
 })

--- a/src/components/post-title.tsx
+++ b/src/components/post-title.tsx
@@ -1,3 +1,5 @@
+import { backQuoteToCodeElement } from '@/utils/backQuoteToCodeElement'
+
 type Props = {
   title: string
 }
@@ -6,7 +8,7 @@ const PostTitle = ({ title }: Props) => {
   return (
     <h1
       className="text-5xl font-bold tracking-tighter leading-tight md:leading-none text-center"
-      dangerouslySetInnerHTML={{ __html: title }}
+      dangerouslySetInnerHTML={{ __html: backQuoteToCodeElement(title) }}
     />
   )
 }

--- a/src/components/post-title.tsx
+++ b/src/components/post-title.tsx
@@ -1,14 +1,13 @@
-import { type ReactNode } from 'react'
-
-interface Props {
-  children?: ReactNode
+type Props = {
+  title: string
 }
 
-const PostTitle = ({ children }: Props) => {
+const PostTitle = ({ title }: Props) => {
   return (
-    <h1 className="text-5xl font-bold tracking-tighter leading-tight md:leading-none text-center">
-      {children}
-    </h1>
+    <h1
+      className="text-5xl font-bold tracking-tighter leading-tight md:leading-none text-center"
+      dangerouslySetInnerHTML={{ __html: title }}
+    />
   )
 }
 

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -1,4 +1,3 @@
-
 import { useEffect } from 'react'
 
 import { useRouter } from 'next/router'
@@ -6,7 +5,6 @@ import ErrorPage from 'next/error'
 import Head from 'next/head'
 
 import Prism from 'prismjs'
-
 
 import { getPostBySlug, getAllPosts } from '@/lib/api'
 import markdownToHtml from '@/lib/markdownToHtml'
@@ -49,7 +47,7 @@ export default function Post({ post, preview }: Props) {
       <Container>
         <Header />
         {router.isFallback ? (
-          <PostTitle>Loading…</PostTitle>
+          <PostTitle title={'Loading…'} />
         ) : (
           <>
             <Head>

--- a/src/utils/backQuoteToCodeElement.test.ts
+++ b/src/utils/backQuoteToCodeElement.test.ts
@@ -1,0 +1,8 @@
+import { backQuoteToCodeElement } from '@/utils/backQuoteToCodeElement'
+
+describe('backQuoteToCodeElement', () => {
+  test('バッククォートで囲まれた文字列がcode要素に変換される', () => {
+    const result = backQuoteToCodeElement('`test`')
+    expect(result).toBe('<code>test</code>')
+  })
+})

--- a/src/utils/backQuoteToCodeElement.ts
+++ b/src/utils/backQuoteToCodeElement.ts
@@ -1,0 +1,3 @@
+export const backQuoteToCodeElement = (markdown: string): string => {
+  return markdown.replace(/`([^`]+)`/g, '<code>$1</code>')
+}


### PR DESCRIPTION
記事の内容部分だけがHTMLに変換されており、タイトルは文字列として扱われていた
タイトルのインラインコードもcode要素に変換するようにした