### PR TITLE
Analyticsコンポーネントの配置場所を修正

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app'
 
+import { Analytics } from '@vercel/analytics/next'
 import '@/styles/index.css'
 import 'prismjs/themes/prism-tomorrow.css'
 import { GoogleAnalytics } from '@next/third-parties/google'
@@ -11,6 +12,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       {process.env.NEXT_PUBLIC_GA_ID && (
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
       )}
+      <Analytics />
     </>
   )
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,7 +1,5 @@
 import { Html, Head, Main, NextScript } from 'next/document'
 
-import { Analytics } from '@vercel/analytics/next'
-
 export default function Document() {
   return (
     <Html lang="ja-JP" className="dark">
@@ -9,7 +7,6 @@ export default function Document() {
       <body className="dark:bg-gray-900 dark:text-slate-50">
         <Main />
         <NextScript />
-        <Analytics />
       </body>
     </Html>
   )


### PR DESCRIPTION
- vercel上でアクセス解析できていない
- page routerのドキュメントでは_appに置いていた
  - https://vercel.com/docs/analytics/package?framework=nextjs