### PR TITLE
GAではなくGTMを設置

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,14 +3,14 @@ import type { AppProps } from 'next/app'
 import { Analytics } from '@vercel/analytics/next'
 import '@/styles/index.css'
 import 'prismjs/themes/prism-tomorrow.css'
-import { GoogleAnalytics } from '@next/third-parties/google'
+import { GoogleTagManager } from '@next/third-parties/google'
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Component {...pageProps} />
-      {process.env.NEXT_PUBLIC_GA_ID && (
-        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+      {process.env.NEXT_PUBLIC_GTM_ID && (
+        <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
       )}
       <Analytics />
     </>


### PR DESCRIPTION
画面遷移時にpage viewイベントが送られていない
Google Analyticsではなく、Google Tag Managerを使用するようにしてみる