### PR TITLE
slugをfilenameに変更

### DIFF
--- a/src/components/post-preview.tsx
+++ b/src/components/post-preview.tsx
@@ -10,11 +10,7 @@ type Props = Pick<Post, 'title' | 'date' | 'filename' | 'tags'>
 
 const PostPreview = ({ title, date, filename, tags = [] }: Props) => {
   return (
-    <Link
-      as={`/posts/${filename}`}
-      href="/posts/[slug]"
-      className="hover:underline"
-    >
+    <Link href={`/posts/${filename}`} className="hover:underline">
       <Card>
         <h3
           className="text-xl mb-3 leading-snug"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -49,7 +49,7 @@ export function getPostByFilename(filename: string): Post | null {
 
 export function getAllPosts() {
   return getPostFiles()
-    .flatMap((slug) => getPostByFilename(slug) ?? [])
+    .flatMap((filename) => getPostByFilename(filename) ?? [])
     .sort((post1, post2) =>
       post1 !== null && post2 !== null && post1.date > post2.date ? -1 : 1,
     )


### PR DESCRIPTION
- slugという単語を使用していたが、filenameに置換した。一部残っていたので追加対応した。
- `Link`コンポーネントのprops指定で引数名が`slug`になっていることが原因でエラーがでていた。Next.js10.0.0から`Link`の`as`propsが不要になったそうなので削除した。
  -  https://nextjs.org/docs/app/api-reference/components/link#version-history
```
https://new-ebisen-blog-git-develop-ebisenttts-projects.vercel.app/posts/[slug]?_rsc=1ld0r 404 (Not Found)
```

