### PR TITLE
prismjsのimportをlayoutからpostに移動

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import { GoogleTagManager } from '@next/third-parties/google'
 import { Analytics } from '@vercel/analytics/next'
-import 'prismjs/themes/prism-tomorrow.css'
 import '@/styles/index.css'
 
 import { TITLE } from '@/constants'

--- a/src/app/posts/[name]/page.tsx
+++ b/src/app/posts/[name]/page.tsx
@@ -7,6 +7,7 @@ import Header from '@/components/header'
 import PostHeader from '@/components/post-header'
 import PostBody from '@/components/post-body'
 import markdownToHtml from '@/lib/markdownToHtml'
+import 'prismjs/themes/prism-tomorrow.css'
 
 import { PageClient } from './page-client'
 


### PR DESCRIPTION
下記のエラーがでていた
```
The resource https://new-ebisen-blog-git-develop-ebisenttts-projects.vercel.app/_next/static/css/d4946af9c6b4ef60.css was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.
```
prism.jsは`posts/[name]`のコードブロックでしか使われないので`layout.tsx`から`posts/[name]/page.tsx`に移動した