### PR TITLE
fix: ensure stable sort order for posts

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -145,6 +145,23 @@ describe('getAllPosts', () => {
     expect(posts[0].title).toBe('B')
   })
 
+  it('should keep original order when dates are equal', async () => {
+    const files = ['a.md', 'b.md']
+    mockReadFile.mockImplementation((path) =>
+      path.endsWith('a.md')
+        ? validMarkdown('A', '2024-06-20')
+        : validMarkdown('B', '2024-06-20'),
+    )
+    jest
+      .spyOn(fs, 'readdirSync')
+      .mockReturnValue(files as unknown as ReturnType<typeof fs.readdirSync>)
+    const posts = await getAllPosts({
+      readFileFn: mockReadFile,
+      postsDirectory: '',
+    })
+    expect(posts.map((p) => p.title)).toEqual(['A', 'B'])
+  })
+
   it('should return empty array if no files', async () => {
     jest
       .spyOn(fs, 'readdirSync')

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -77,5 +77,9 @@ export async function getAllPosts(
   )
   return posts
     .filter((post): post is Post => post !== null)
-    .sort((post1, post2) => (post1.date > post2.date ? -1 : 1))
+    .sort((post1, post2) => {
+      if (post1.date > post2.date) return -1
+      if (post1.date < post2.date) return 1
+      return 0
+    })
 }


### PR DESCRIPTION
## Summary
- fix sorting in getAllPosts to handle equal dates
- add regression test for equal date sorting

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4400778548327aad9771dae97a164