### PR TITLE
ci: cancel in-progress runs per branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ on:
       - main
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a change to the GitHub Actions workflow configuration to improve CI efficiency and prevent overlapping runs.

Workflow improvements:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR13-R16): Added a `concurrency` group to ensure that only one run of the workflow per branch is active at a time, automatically cancelling any in-progress runs for the same branch.