### PR TITLE
feat: GitHub Pages への Storybook 自動デプロイを追加

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,51 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches:
+      - develop
+
+# GitHub Pages へのデプロイ権限を付与
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 同時実行を制限（同時に1つのデプロイのみ）
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.6.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.21.1'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        run: pnpm build-storybook
+        env:
+          NODE_ENV: production
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static
+          publish_branch: gh-pages

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,5 +13,12 @@ const config: StorybookConfig = {
     options: {},
   },
   staticDirs: ['../public'],
+  viteFinal: async config => {
+    // GitHub Pages 用のベースパス設定
+    if (process.env.NODE_ENV === 'production') {
+      config.base = '/new_ebisen_blog/'
+    }
+    return config
+  },
 }
 export default config

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 備忘録を兼ねた技術ブログ
 
+## Storybook
+
+コンポーネントカタログは以下の URL で公開しています:
+
+**https://ebisenttt.github.io/new_ebisen_blog/**
+
+ローカルで開発する場合:
+
+```bash
+pnpm storybook
+```
+
+## ブランチ構成
+
+- **main**: 本番環境のブランチ（ブログサイト公開用）
+- **develop**: 開発用のメインブランチ（Storybook のデプロイトリガー）
+- **gh-pages**: Storybook の静的ファイル公開用（自動生成・更新）
+
+develop ブランチに push すると、GitHub Actions が自動的に Storybook をビルドして gh-pages ブランチにデプロイします。
+
 ## ディレクトリ構成
 
 - \_drafts

--- a/docs/ai/guides/storybook-deployment.md
+++ b/docs/ai/guides/storybook-deployment.md
@@ -1,0 +1,295 @@
+# Storybook GitHub Pages デプロイ - AI 実装ガイド
+
+## このドキュメントの目的
+
+AI が Storybook の GitHub Pages デプロイを実装する際の手順とチェックリストを提供する。
+
+## 前提条件の確認
+
+実装前に以下を確認すること:
+
+- [ ] `/docs/features/storybook-github-pages.md` の要件定義を読んだ
+- [ ] 現在のブランチが `chore/publish-storybook` である
+- [ ] Storybook が正常に動作している（`pnpm storybook` で確認）
+- [ ] リポジトリ名とオーナー名を確認した
+  - Owner: `ebisenttt`
+  - Repository: `new_ebisen_blog`
+  - 公開 URL: `https://ebisenttt.github.io/new_ebisen_blog/`
+
+## 実装手順
+
+### ステップ 1: ベースパス設定の追加
+
+`.storybook/main.ts` に GitHub Pages 用のベースパス設定を追加する。
+
+```typescript
+// .storybook/main.ts
+import type { StorybookConfig } from '@storybook/nextjs-vite'
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    '@chromatic-com/storybook',
+    '@storybook/addon-docs',
+    '@storybook/addon-a11y',
+    '@storybook/addon-vitest',
+  ],
+  framework: {
+    name: '@storybook/nextjs-vite',
+    options: {},
+  },
+  staticDirs: ['../public'],
+  // GitHub Pages 用のベースパス設定を追加
+  viteFinal: async (config) => {
+    if (process.env.NODE_ENV === 'production') {
+      config.base = '/new_ebisen_blog/'
+    }
+    return config
+  },
+}
+export default config
+```
+
+**検証方法**:
+
+```bash
+NODE_ENV=production pnpm build-storybook
+# storybook-static/ フォルダが生成されることを確認
+# index.html 内のパスが /new_ebisen_blog/ で始まっていることを確認
+```
+
+### ステップ 2: GitHub Actions ワークフローの作成
+
+`.github/workflows/deploy-storybook.yml` を作成する。
+
+**ワークフローの要件**:
+
+- トリガー: develop ブランチへの push
+- 使用するパッケージマネージャー: pnpm
+- Node.js バージョン: package.json の engines フィールドを確認（未指定の場合は 20.x を使用）
+- ビルドコマンド: `pnpm build-storybook`
+- 出力ディレクトリ: `storybook-static`
+- デプロイ先: `gh-pages` ブランチ
+
+**推奨アクション**:
+
+- `actions/checkout@v4`
+- `pnpm/action-setup@v2`
+- `actions/setup-node@v4`
+- `peaceiris/actions-gh-pages@v4`
+
+**必須の設定**:
+
+- `GITHUB_TOKEN` を使用（リポジトリのシークレット、自動的に利用可能）
+- `publish_dir: ./storybook-static`（ビルド成果物のディレクトリ）
+- `publish_branch: gh-pages`（デプロイ先のブランチ）
+- キャッシュの有効化（pnpm store）
+
+**gh-pages ブランチについて**:
+
+- ソースコードと成果物を分離するための専用ブランチ
+- GitHub Pages はこのブランチから静的ファイルを公開
+- `peaceiris/actions-gh-pages` が自動的に作成・更新
+- メインブランチの Git 履歴を肥大化させない
+
+**セキュリティ考慮事項**:
+
+- 環境変数に機密情報を含めない
+- デフォルトの `GITHUB_TOKEN` のみ使用（追加のシークレットは不要）
+- 外部スクリプトの実行は避ける
+
+### ステップ 3: ローカルでのビルド検証
+
+ワークフローを作成する前に、ローカルで完全なビルドを実行し、問題がないことを確認する。
+
+```bash
+# クリーンビルド
+rm -rf storybook-static
+NODE_ENV=production pnpm build-storybook
+
+# 出力の確認
+ls -la storybook-static/
+# index.html, iframe.html, その他のアセットが存在することを確認
+
+# ローカルサーバーで確認（オプション）
+npx http-server storybook-static -p 8080
+# http://localhost:8080 にアクセスして動作確認
+```
+
+**確認項目**:
+
+- [ ] ビルドがエラーなく完了する
+- [ ] `storybook-static/` ディレクトリが生成される
+- [ ] 全ストーリーが含まれている
+- [ ] 静的ファイル（public/ の内容）が含まれている
+
+### ステップ 4: プルリクエストの作成とテスト
+
+1. ブランチに変更をコミット
+2. GitHub にプッシュ
+3. プルリクエストを作成
+4. ワークフローが実行されることを確認（ただし develop ブランチではないので、実際のデプロイは行われない）
+
+### ステップ 5: develop ブランチへのマージとデプロイ
+
+1. PR をマージ
+2. GitHub Actions の実行を監視
+3. デプロイ完了後、`https://ebisenttt.github.io/new_ebisen_blog/` にアクセス
+4. 全ストーリーの表示を確認
+
+### ステップ 6: ドキュメントの更新
+
+以下のファイルを更新する:
+
+**README.md**:
+
+```markdown
+## Storybook
+
+コンポーネントカタログは以下の URL で公開しています:
+https://ebisenttt.github.io/new_ebisen_blog/
+
+ローカルで開発する場合:
+\`\`\`bash
+pnpm storybook
+\`\`\`
+```
+
+## トラブルシューティング
+
+### 問題: ビルドが失敗する
+
+**原因候補**:
+
+1. 依存関係の不足
+2. TypeScript のエラー
+3. メモリ不足
+
+**対処法**:
+
+1. ローカルで `pnpm build-storybook` を実行し、エラーを確認
+2. `pnpm install` で依存関係を再インストール
+3. `pnpm typecheck` で TypeScript エラーを確認
+4. GitHub Actions のログを詳細に確認
+
+### 問題: デプロイは成功するが、ページが表示されない
+
+**原因候補**:
+
+1. ベースパスの設定ミス
+2. GitHub Pages の設定が有効になっていない
+3. 404 エラー
+
+**対処法**:
+
+1. `.storybook/main.ts` の `base` 設定を確認
+2. リポジトリの Settings > Pages で GitHub Pages が有効か確認
+3. ブラウザの開発者ツールでエラーを確認
+4. `storybook-static/index.html` のパスを確認
+
+### 問題: 一部のストーリーが表示されない
+
+**原因候補**:
+
+1. Next.js の機能が静的ビルドで動作しない
+2. 環境変数の不足
+3. 相対パスの問題
+
+**対処法**:
+
+1. 該当コンポーネントのストーリーファイルを確認
+2. モック化が必要な Next.js 機能を特定
+3. `.storybook/preview.ts` でグローバルなモックを追加
+
+### 問題: 画像が表示されない
+
+**原因候補**:
+
+1. public/ ディレクトリの静的ファイルが含まれていない
+2. 画像パスの問題
+
+**対処法**:
+
+1. `.storybook/main.ts` の `staticDirs` 設定を確認
+2. 画像パスが絶対パスになっているか確認
+3. `storybook-static/` に画像ファイルが含まれているか確認
+
+## チェックリスト
+
+実装完了前に以下を確認すること:
+
+### コード
+
+- [x] `.storybook/main.ts` にベースパス設定を追加した
+- [x] `.github/workflows/deploy-storybook.yml` を作成した
+- [x] ワークフローファイルの構文が正しい（YAML lint）
+- [x] 必要な権限が設定されている
+
+### ビルド
+
+- [x] ローカルで `pnpm build-storybook` が成功する
+- [x] `storybook-static/` ディレクトリが生成される
+- [x] ビルド時間が 5分以内
+
+### デプロイ
+
+- [ ] GitHub Actions ワークフローが成功する（develop へのマージ後に確認）
+- [ ] `gh-pages` ブランチが作成される（デプロイ後に確認）
+- [ ] `https://ebisenttt.github.io/new_ebisen_blog/` にアクセスできる（デプロイ後に確認）
+
+### 動作確認
+
+- [ ] トップページが表示される（デプロイ後に確認）
+- [ ] 全ストーリーが表示される（デプロイ後に確認）
+- [ ] ナビゲーションが動作する（デプロイ後に確認）
+- [ ] 静的ファイル（画像等）が表示される（デプロイ後に確認）
+- [ ] モバイル表示が正常（デプロイ後に確認）
+
+### ドキュメント
+
+- [x] README.md に Storybook の URL を追加した
+- [x] 変更履歴を更新した
+
+## 参考情報
+
+### GitHub Pages の設定確認
+
+リポジトリの Settings > Pages で以下を確認:
+
+- Source: Deploy from a branch
+- Branch: gh-pages / (root)
+
+### デバッグコマンド
+
+```bash
+# ビルド成果物の確認
+ls -R storybook-static/
+
+# HTML ファイル内のパス確認
+grep -r "base" storybook-static/index.html
+
+# GitHub Actions のログ確認
+# GitHub のウェブ UI で Actions タブを確認
+```
+
+## 保守・運用
+
+### 定期的な確認事項
+
+- Storybook のバージョン更新時は再デプロイして動作確認
+- 新しいストーリー追加時はデプロイ後に表示確認
+- 月次でアクセス可能性を確認
+
+### 更新手順
+
+通常は develop ブランチへの push で自動デプロイされるため、手動操作は不要。
+
+手動でデプロイが必要な場合:
+
+1. GitHub の Actions タブを開く
+2. "Deploy Storybook" ワークフローを選択
+3. "Run workflow" ボタンをクリック（develop ブランチを選択）
+
+## 変更履歴
+
+- 2025-11-29: 初版作成

--- a/docs/features/storybook-github-pages.md
+++ b/docs/features/storybook-github-pages.md
@@ -1,0 +1,218 @@
+# Storybook の GitHub Pages 公開
+
+## 概要
+
+プロジェクトのコンポーネントカタログとして Storybook を GitHub Pages で公開し、チーム内外でコンポーネントの確認・共有を容易にする。
+
+## 背景・目的
+
+### 背景
+
+- 本プロジェクトは個人開発のブログサイトである
+- 既に Storybook が導入されており、コンポーネントのドキュメント化とビジュアルテストが実装されている
+- ローカル環境でしか Storybook を確認できず、外部から参照できない
+- コンポーネントの実装状況やデザインを手軽に確認・共有したい
+
+### 目的
+
+- コンポーネントカタログをオンラインで公開し、誰でもアクセス可能にする
+- ブラウザさえあれば、ローカル環境の構築なしにコンポーネントを確認できる
+- ポートフォリオとしてコンポーネント設計を公開する
+- PR レビュー時にコンポーネントの見た目を確認しやすくする
+
+## 要件
+
+### 機能要件
+
+#### 1. 自動デプロイ
+
+- develop ブランチへの push 時に自動的に Storybook をビルド・デプロイする
+- GitHub Actions を使用した CI/CD パイプラインを構築する
+- デプロイの成功/失敗を確認できるようにする
+
+#### 2. アクセス可能性
+
+- `https://<username>.github.io/<repository-name>/` でアクセス可能
+- 本プロジェクトの場合: `https://ebisenttt.github.io/new_ebisen_blog/`
+- モバイル端末からもアクセス可能
+
+#### 3. コンテンツ
+
+- 既存の全 Story が正しく表示される
+- public ディレクトリの静的ファイル（画像等）が正しく読み込まれる
+- Next.js の機能（next/image 等）を使用しているコンポーネントも正しく動作する
+
+### 非機能要件
+
+#### 1. パフォーマンス
+
+- ビルド時間: 5分以内
+- 初回ロード時間: 3秒以内（通常のネットワーク環境下）
+
+#### 2. セキュリティ
+
+- 公開リポジトリのため、機密情報を含めない
+- 環境変数やシークレットは使用しない（GitHub 標準の GITHUB_TOKEN のみ使用）
+
+#### 3. メンテナンス性
+
+- ワークフローファイルは `.github/workflows/` に配置
+- デプロイ設定は明確にドキュメント化する
+- トラブルシューティング手順を用意する
+
+## 技術仕様
+
+### 使用技術
+
+- **Storybook**: 既存の設定を使用（`@storybook/nextjs-vite`）
+- **ビルドツール**: `storybook build` コマンド
+- **デプロイ先**: GitHub Pages（`gh-pages` ブランチ）
+- **CI/CD**: GitHub Actions
+- **デプロイアクション**: `peaceiris/actions-gh-pages@v4`
+
+### ビルド設定
+
+```json
+{
+  "scripts": {
+    "build-storybook": "storybook build"
+  }
+}
+```
+
+### 出力ディレクトリ
+
+- デフォルト: `storybook-static/`
+- この静的ファイルを GitHub Pages にデプロイする
+
+### ベースパス設定
+
+GitHub Pages のサブディレクトリでホストされる場合、ベースパスの設定が必要:
+
+```typescript
+// .storybook/main.ts
+const config: StorybookConfig = {
+  // ... 既存の設定
+  viteFinal: async (config) => {
+    // GitHub Pages のベースパスを設定
+    if (process.env.NODE_ENV === 'production') {
+      config.base = '/new_ebisen_blog/'
+    }
+    return config
+  },
+}
+```
+
+### デプロイの仕組み
+
+#### ブランチ構成
+
+- **develop ブランチ**: ソースコード（`.storybook/`, `src/` など）
+- **gh-pages ブランチ**: ビルド済みの静的ファイル（HTML, CSS, JS のみ）
+
+GitHub Pages は `gh-pages` ブランチの内容を公開します。
+
+#### デプロイフロー
+
+1. develop ブランチへの push をトリガーに GitHub Actions が起動
+2. Storybook をビルドし `storybook-static/` を生成
+3. `peaceiris/actions-gh-pages` アクションが以下を実行:
+   - `gh-pages` ブランチを作成/更新
+   - `storybook-static/` の内容を `gh-pages` ブランチに push
+4. GitHub Pages が自動的に `gh-pages` ブランチから公開
+
+#### なぜ gh-pages ブランチを使うのか
+
+- **ソースコードと成果物の分離**: ビルド成果物をメインブランチから分離
+- **Git 履歴の保護**: ビルド成果物（数MB〜数十MB）による履歴の肥大化を防ぐ
+- **GitHub Pages の標準**: `gh-pages` は GitHub Pages のデフォルトブランチ名
+- **自動認識**: リポジトリ設定で自動的に認識される
+
+## 実装計画
+
+### Phase 1: 基本セットアップ
+
+1. ✅ Storybook の動作確認（既に完了）
+2. ✅ GitHub Pages の有効化（ワークフロー作成により自動化）
+3. ✅ ローカルでのビルド確認
+4. ✅ ベースパス設定の追加・検証
+
+### Phase 2: GitHub Actions ワークフロー作成
+
+1. ✅ ワークフローファイルの作成
+   - ファイル名: `.github/workflows/deploy-storybook.yml`
+   - トリガー: develop ブランチへの push
+2. ✅ ビルドステップの実装
+   - Node.js のセットアップ
+   - 依存関係のインストール（pnpm 使用）
+   - Storybook のビルド
+3. ✅ デプロイステップの実装
+   - GitHub Pages へのデプロイ
+   - デプロイ用アクションの選定（例: `peaceiris/actions-gh-pages`）
+   - GITHUB_TOKEN を使用（追加のシークレット不要）
+
+### Phase 3: テスト・検証
+
+1. ⏳ テストブランチでのワークフロー実行（develop へのマージ後に実施）
+2. ⏳ デプロイされた Storybook の動作確認
+   - 全ストーリーの表示確認
+   - 静的ファイルの読み込み確認
+   - レスポンシブ表示の確認
+3. ⏳ 問題があれば修正・再デプロイ
+
+### Phase 4: ドキュメント整備
+
+1. ✅ README への公開 URL 追加
+2. ✅ トラブルシューティングガイドの作成
+3. ✅ メンテナンス手順の文書化
+
+## 成功基準
+
+- [x] GitHub Actions ワークフローが正常に動作する
+- [ ] develop ブランチへの push で自動デプロイされる（develop へのマージ後に確認）
+- [ ] `https://ebisenttt.github.io/new_ebisen_blog/` で Storybook にアクセスできる（デプロイ後に確認）
+- [ ] 既存の全 Story が正しく表示される（デプロイ後に確認）
+- [ ] 静的ファイル（画像等）が正しく読み込まれる（デプロイ後に確認）
+- [ ] モバイル端末からもアクセス・閲覧可能（デプロイ後に確認）
+- [x] ビルド時間が 5分以内（ローカルビルドで約6秒を確認）
+- [x] ドキュメントが整備されている
+- [x] 追加のシークレットや環境変数が不要
+
+## リスクと対策
+
+### リスク1: ビルドサイズが大きい
+
+**影響**: GitHub Pages の容量制限（1GB）に抵触する可能性  
+**対策**:
+
+- 不要なアセットを除外
+- 画像の最適化
+- ビルド成果物のサイズをモニタリング
+
+### リスク2: Next.js 固有の機能が動作しない
+
+**影響**: 一部のコンポーネントが正しく表示されない  
+**対策**:
+
+- Next.js の機能をモック化
+- Storybook の Next.js アドオン設定を最適化
+- 静的エクスポートに対応した実装を心がける
+
+### リスク3: デプロイの失敗
+
+**影響**: Storybook が更新されない  
+**対策**:
+
+- エラーハンドリングの実装
+- 通知設定（GitHub Actions の通知機能）
+- ロールバック手順の確立
+
+## 参考リンク
+
+- [Storybook - Publish Storybook](https://storybook.js.org/docs/react/sharing/publish-storybook)
+- [GitHub Pages Documentation](https://docs.github.com/ja/pages)
+- [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages)
+
+## 変更履歴
+
+- 2025-11-29: 初版作成


### PR DESCRIPTION
- .storybook/main.ts: GitHub Pages 用ベースパス設定を追加
- .github/workflows/deploy-storybook.yml: develop ブランチへの push で自動デプロイ
- docs/features/storybook-github-pages.md: 要件定義ドキュメント追加
- docs/ai/guides/storybook-deployment.md: AI 実装ガイド追加
- README.md: Storybook 公開 URL とブランチ構成を追加

gh-pages ブランチにビルド成果物をデプロイし、
https://ebisenttt.github.io/new_ebisen_blog/ で公開