### PR TITLE
fix:gh-pagesデプロイに使用するtokenを修正

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_PAT }}
           publish_dir: ./storybook-static
           publish_branch: gh-pages


### PR DESCRIPTION
GITHUB_TOKENではpushが認可されなかった。PATを発行してworkflowで使用するように修正した。