### PR TITLE
feat: integrate Qiita posts and update tag badges

### DIFF
--- a/src/entities/post/model/api/server/qiita.ts
+++ b/src/entities/post/model/api/server/qiita.ts
@@ -1,0 +1,86 @@
+import type { Post } from '../../types'
+
+import { decodeExternalUrl, encodeExternalFilename } from '../../helpers'
+
+const QIITA_ENDPOINT = 'https://qiita.com/api/v2/users/ebisenttt/items?page='
+
+export async function fetchQiitaPosts(): Promise<Post[]> {
+  const all: Post[] = []
+
+  for (let page = 1; ; page += 1) {
+    const url = `${QIITA_ENDPOINT}${page}&per_page=100`
+    let json: QiitaItem[] | null = null
+    try {
+      const res = await fetch(url, { next: { revalidate: 86400 } })
+      if (!res.ok) break
+      json = (await res.json()) as QiitaItem[]
+    } catch {
+      break
+    }
+
+    if (!Array.isArray(json) || json.length === 0) break
+
+    const mapped = json
+      .map<Post | null>((item) => {
+        const title = item.title ?? null
+        const date = item.created_at ?? null
+        const url = item.url ?? null
+        if (!title || !date || !url) return null
+        const tags = (item.tags ?? [])
+          .map((t) => t.name)
+          .filter((name): name is string => !!name)
+
+        return {
+          title,
+          date,
+          content: '',
+          filename: encodeExternalFilename(url),
+          tags,
+        }
+      })
+      .filter((post): post is Post => post !== null)
+
+    const seen = new Set<string>()
+    mapped.forEach((post) => {
+      const externalUrl = decodeExternalUrl(post.filename)
+      if (!externalUrl) return
+      if (seen.has(externalUrl)) return
+      seen.add(externalUrl)
+      all.push(post)
+    })
+
+    // Qiita returns empty array if page is out of range, or fewer items than per_page if it's the last page.
+    if (json.length < 100) break
+  }
+
+  return all
+    .slice()
+    .sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0))
+}
+
+type QiitaTag = {
+  name?: string
+  versions?: string[]
+}
+
+type QiitaItem = {
+  rendered_body?: string
+  body?: string
+  coediting?: boolean
+  comments_count?: number
+  created_at?: string
+  group?: unknown
+  id?: string
+  likes_count?: number
+  private?: boolean
+  reactions_count?: number
+  tags?: QiitaTag[]
+  title?: string
+  updated_at?: string
+  url?: string
+  user?: unknown
+  page_views_count?: number
+  team_membership?: unknown
+  organization_url_name?: unknown
+  slide?: boolean
+}

--- a/src/entities/post/model/api/server/queries.test.ts
+++ b/src/entities/post/model/api/server/queries.test.ts
@@ -3,8 +3,12 @@ import fs from 'fs'
 jest.mock('./note', () => ({
   fetchNotePosts: jest.fn(),
 }))
+jest.mock('./qiita', () => ({
+  fetchQiitaPosts: jest.fn(),
+}))
 
 import { fetchNotePosts } from './note'
+import { fetchQiitaPosts } from './qiita'
 import { getAllPosts, getAllPostsMerged } from './queries'
 
 describe('getAllPosts', () => {
@@ -98,19 +102,32 @@ describe('getAllPostsMerged', () => {
   const fetchNotePostsMock = fetchNotePosts as jest.MockedFunction<
     typeof fetchNotePosts
   >
+  const fetchQiitaPostsMock = fetchQiitaPosts as jest.MockedFunction<
+    typeof fetchQiitaPosts
+  >
 
   afterEach(() => {
     jest.restoreAllMocks()
     fetchNotePostsMock.mockReset()
+    fetchQiitaPostsMock.mockReset()
   })
 
   it('merges local and external posts, deduplicating by filename', async () => {
     fetchNotePostsMock.mockResolvedValueOnce([
       {
-        title: 'External',
+        title: 'Note External',
         date: '2024-06-23',
         content: '',
         filename: 'note__external',
+        tags: ['tag'],
+      },
+    ])
+    fetchQiitaPostsMock.mockResolvedValueOnce([
+      {
+        title: 'Qiita External',
+        date: '2024-06-24',
+        content: '',
+        filename: 'qiita__external',
         tags: ['tag'],
       },
       {
@@ -145,14 +162,16 @@ describe('getAllPostsMerged', () => {
     })
 
     expect(posts.map((p) => p.title)).toEqual([
-      'External',
+      'Qiita External',
+      'Note External',
       'Local',
       'Duplicate Local',
     ])
   })
 
-  it('falls back to local posts when fetchNotePosts throws', async () => {
+  it('falls back to local posts when both fetch functions throw', async () => {
     fetchNotePostsMock.mockRejectedValueOnce(new Error('network error'))
+    fetchQiitaPostsMock.mockRejectedValueOnce(new Error('network error'))
 
     const mockReadFile = jest.fn()
     const files = ['local.md']
@@ -172,5 +191,31 @@ describe('getAllPostsMerged', () => {
 
     expect(posts).toHaveLength(1)
     expect(posts[0].title).toBe('Only Local')
+  })
+
+  it('continues if one fetch function fails', async () => {
+    fetchNotePostsMock.mockRejectedValueOnce(new Error('network error'))
+    fetchQiitaPostsMock.mockResolvedValueOnce([
+      {
+        title: 'Qiita',
+        date: '2024-06-25',
+        content: '',
+        filename: 'qiita__1',
+        tags: [],
+      },
+    ])
+
+    const mockReadFile = jest.fn()
+    jest
+      .spyOn(fs, 'readdirSync')
+      .mockReturnValue([] as unknown as ReturnType<typeof fs.readdirSync>)
+
+    const posts = await getAllPostsMerged({
+      readFileFn: mockReadFile,
+      postsDirectory: '',
+    })
+
+    expect(posts).toHaveLength(1)
+    expect(posts[0].title).toBe('Qiita')
   })
 })

--- a/src/entities/post/model/api/server/queries.ts
+++ b/src/entities/post/model/api/server/queries.ts
@@ -3,6 +3,7 @@ import { getPostFiles, postsDirectory } from '@/shared/lib/file'
 import type { Post } from '../../types'
 
 import { fetchNotePosts } from './note'
+import { fetchQiitaPosts } from './qiita'
 import { getPostByFilename, type GetPostOptions } from './markdown'
 
 export async function getAllPosts(
@@ -26,16 +27,17 @@ export async function getAllPostsMerged(
   options: GetPostOptions = {},
 ): Promise<Post[]> {
   const local = await getAllPosts(options)
-  try {
-    const external = await fetchNotePosts()
-    const map = new Map(local.map((p) => [p.filename, p]))
-    for (const p of external) {
-      if (!map.has(p.filename)) map.set(p.filename, p)
-    }
-    return Array.from(map.values()).sort((a, b) =>
-      a.date > b.date ? -1 : a.date < b.date ? 1 : 0,
-    )
-  } catch {
-    return local
+  const [note, qiita] = await Promise.all([
+    fetchNotePosts().catch(() => []),
+    fetchQiitaPosts().catch(() => []),
+  ])
+  const external = [...note, ...qiita]
+
+  const map = new Map(local.map((p) => [p.filename, p]))
+  for (const p of external) {
+    if (!map.has(p.filename)) map.set(p.filename, p)
   }
+  return Array.from(map.values()).sort((a, b) =>
+    a.date > b.date ? -1 : a.date < b.date ? 1 : 0,
+  )
 }

--- a/src/entities/post/model/helpers.ts
+++ b/src/entities/post/model/helpers.ts
@@ -1,14 +1,28 @@
-const EXTERNAL_PREFIX = 'note__'
+const NOTE_PREFIX = 'note__'
+const QIITA_PREFIX = 'qiita__'
+
+const DOMAIN_PREFIXES = [
+  { domain: 'note.com', prefix: NOTE_PREFIX },
+  { domain: 'qiita.com', prefix: QIITA_PREFIX },
+]
 
 export function encodeExternalFilename(url: string): string {
+  const match = DOMAIN_PREFIXES.find((item) => url.includes(item.domain))
+  const prefix = match ? match.prefix : NOTE_PREFIX
+
   const b64 = Buffer.from(url, 'utf-8').toString('base64')
   const b64url = b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
-  return `${EXTERNAL_PREFIX}${b64url}`
+  return `${prefix}${b64url}`
 }
 
 export function decodeExternalUrl(filename: string): string | null {
-  if (!filename.startsWith(EXTERNAL_PREFIX)) return null
-  const b64url = filename.slice(EXTERNAL_PREFIX.length)
+  const match = DOMAIN_PREFIXES.find((item) => filename.startsWith(item.prefix))
+
+  if (!match && !filename.startsWith(NOTE_PREFIX)) return null
+
+  const prefix = match ? match.prefix : NOTE_PREFIX
+
+  const b64url = filename.slice(prefix.length)
   const pad = b64url.length % 4 === 0 ? '' : '='.repeat(4 - (b64url.length % 4))
   const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/') + pad
   try {
@@ -20,7 +34,8 @@ export function decodeExternalUrl(filename: string): string | null {
 }
 
 export const postExternalHelpers = {
-  EXTERNAL_PREFIX,
+  NOTE_PREFIX,
+  QIITA_PREFIX,
   encodeExternalFilename,
   decodeExternalUrl,
 }

--- a/src/entities/post/model/index.ts
+++ b/src/entities/post/model/index.ts
@@ -1,3 +1,4 @@
 export * from './types'
 export * from './api/server/note'
+export * from './api/server/qiita'
 export * from './helpers'

--- a/src/shared/ui/Badge/Badge.tsx
+++ b/src/shared/ui/Badge/Badge.tsx
@@ -47,9 +47,61 @@ const BADGE_STYLES: Record<string, BadgeStyle> = {
     icon: <i className="devicon-typescript-plain colored"></i>,
     color: 'dark:bg-blue-900 dark:text-blue-300',
   },
+  TypeScript: {
+    icon: <i className="devicon-typescript-plain colored"></i>,
+    color: 'dark:bg-blue-900 dark:text-blue-300',
+  },
   eslint: {
     icon: <i className="devicon-eslint-plain colored"></i>,
     color: 'dark:bg-violet-500 dark:text-violet-300',
+  },
+  ESLint: {
+    icon: <i className="devicon-eslint-plain colored"></i>,
+    color: 'dark:bg-violet-500 dark:text-violet-300',
+  },
+  javascript: {
+    icon: <i className="devicon-javascript-plain colored"></i>,
+    color: 'dark:bg-yellow-900 dark:text-yellow-300',
+  },
+  JavaScript: {
+    icon: <i className="devicon-javascript-plain colored"></i>,
+    color: 'dark:bg-yellow-900 dark:text-yellow-300',
+  },
+  'next.js': {
+    icon: <i className="devicon-nextjs-plain"></i>,
+    color: 'dark:bg-gray-950 dark:text-gray-200',
+  },
+  'Next.js': {
+    icon: <i className="devicon-nextjs-plain"></i>,
+    color: 'dark:bg-gray-950 dark:text-gray-200',
+  },
+  react: {
+    icon: <i className="devicon-react-original colored"></i>,
+    color: 'dark:bg-sky-900 dark:text-sky-300',
+  },
+  React: {
+    icon: <i className="devicon-react-original colored"></i>,
+    color: 'dark:bg-sky-900 dark:text-sky-300',
+  },
+  pnpm: {
+    icon: <i className="devicon-pnpm-plain colored"></i>,
+    color: 'dark:bg-orange-800 dark:text-orange-200',
+  },
+  jest: {
+    icon: <i className="devicon-jest-plain colored"></i>,
+    color: 'dark:bg-rose-900 dark:text-rose-300',
+  },
+  Jest: {
+    icon: <i className="devicon-jest-plain colored"></i>,
+    color: 'dark:bg-rose-900 dark:text-rose-300',
+  },
+  java: {
+    icon: <i className="devicon-java-plain colored"></i>,
+    color: 'dark:bg-red-900 dark:text-red-300',
+  },
+  Java: {
+    icon: <i className="devicon-java-plain colored"></i>,
+    color: 'dark:bg-red-900 dark:text-red-300',
   },
 }
 


### PR DESCRIPTION
## 概要
Qiitaの記事 () をブログの一覧に統合し、主要な技術タグにアイコンを追加しました。

## 変更点

### Qiita連携
- **記事取得**:  を追加し、Qiita API v2 から記事を取得するロジックを実装しました。
- **マージ処理**:  で Note 記事と Qiita 記事を並列で取得し、ローカル記事とマージするように変更しました。
- **URL管理**:  を拡張し、 だけでなく  も識別できるように  /  を導入しました。

### UI改善
- **タグアイコン**:  コンポーネントを更新し、以下のタグにアイコンを追加しました。
    - JavaScript / Next.js / React / pnpm / Jest / Java
- **視認性向上**: Next.js タグの背景色をカード背景よりも暗い色 () に調整し、区別しやすくしました。

## テスト
-  のモック作成と  へのテストケース追加を行い、正常にマージ・ソートされることを確認しました。
-  コンポーネントのテストもパスしています。