### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.6.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.21.1'
           cache: 'pnpm'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Check for existing PR with title "release"
         id: check_pr

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -22,15 +22,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v5
         with:
           version: 10.6.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.21.1'
           cache: 'pnpm'

--- a/.github/workflows/tweet_new_posts.yaml
+++ b/.github/workflows/tweet_new_posts.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -25,12 +25,12 @@ jobs:
           pip install tweepy
 
       - name: Checkout base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Tweet
         env:


### PR DESCRIPTION
## Summary

- `actions/checkout` v2/v3/v4 → v6（Node.js 24対応）
- `actions/setup-node` v4 → v6（Node.js 24対応）
- `pnpm/action-setup` v2/v4 → v5（Node.js 24対応）
- `actions/setup-python` v4 → v6（Node.js 24対応）

## 背景

GitHub ActionsのNode.js 20が非推奨となり、以下の警告が出ていたため対応：

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Test plan

- [ ] CI（build-and-test）がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)