### PR TITLE
ci: add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tweet_new_posts.yaml
+++ b/.github/workflows/tweet_new_posts.yaml
@@ -13,6 +13,8 @@ jobs:
   tweet:
     runs-on: ubuntu-latest
     environment: Production
+    permissions:
+      contents: read
 
     steps:
       - name: Set up Python


### PR DESCRIPTION
## Summary

Add minimal `permissions` blocks to each workflow to limit GITHUB_TOKEN scope.

- `ci.yaml`: `contents: read` (closes code scanning #6)
- `create-release-pr.yaml`: `contents: read` + `pull-requests: write` (closes code scanning #5)
- `tweet_new_posts.yaml`: `contents: read` (closes code scanning #7)

## Test plan

- [x] YAML syntax verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)