### PR TITLE
fix: validate name parameter in metadata API to prevent SSRF

### DIFF
--- a/src/app/api/metadata/route.ts
+++ b/src/app/api/metadata/route.ts
@@ -16,6 +16,13 @@ export async function GET(req: NextRequest) {
     )
   }
 
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(name)) {
+    return NextResponse.json<ResponseBody>(
+      { error: 'invalid name' },
+      { status: 400 },
+    )
+  }
+
   // /posts/{name} のHTMLを取得
   const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL
     ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`


### PR DESCRIPTION
## Summary

- Add input validation for the `name` query parameter in `src/app/api/metadata/route.ts`
- Only allow alphanumeric characters, hyphens, and underscores (`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
- Return 400 for invalid input instead of forwarding user-controlled values into the fetch URL

Closes code scanning alert #4 (js/request-forgery).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `oxlint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)