### PR TITLE
fix: grant write permissions to Claude workflows for PR/issue comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary

- `claude-code-review.yml`: `pull-requests: read` → `write` に変更
- `claude.yml`: `pull-requests: read` → `write`、`issues: read` → `write` に変更

## 背景

`pull-requests: write` 権限がないと Claude がPRにコメントを投稿できず、ワークフローは実行されてもコメントが付かない状態になっていた。

## Test plan

- [ ] PRを作成して `claude-code-review` ワークフローが実行され、PRにコメントが付くことを確認
- [ ] PRのコメントで `@claude` をメンションして返答があることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)