### PR TITLE
chore: add wt config and update plan command workflow

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -2,5 +2,11 @@
 
 計画を修正する際は必ず `tmp.md` も更新すること。
 
-プランが確定したら、`docs/ai/plans/README.md` の命名規則（`{type}-{description}.md`）に従って `tmp.md` をリネームする。
-その後、プランに沿って実装を進める。
+プランが確定したら以下の順で実行する：
+
+1. `docs/ai/plans/README.md` の命名規則（`{type}-{description}.md`）に従って `tmp.md` をリネームする
+2. `wt switch --create {type}/{description}` でworktreeを作成する（ブランチ名はリネームしたファイル名の先頭ハイフンをスラッシュに変換した形式。例: `ci-coverage-report.md` → `ci/coverage-report`）
+3. リネームしたプランファイルをworktreeの `docs/ai/plans/` にコピーする
+4. worktreeで実装を進める
+5. 実装が完了したら `gh pr create --base develop` でPRを作成する
+6. PRがmergeされたら `wt remove` でworktreeを削除する

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,2 @@
+[post-start]
+copy = "wt step copy-ignored"


### PR DESCRIPTION
## Summary

- `.config/wt.toml` を追加: worktree 作成時に `wt step copy-ignored` を `post-start` フックで自動実行し、`node_modules` など gitignore 対象ファイルをコピーする
- `.claude/commands/plan` を更新: プラン確定後の worktree 作成・プランファイルコピー・PR 作成・worktree 削除の手順を追加

## Test plan

- [ ] `wt switch --create` で worktree を作成し、バックグラウンドで `node_modules` がコピーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)